### PR TITLE
Fix TableHeader output format and repair test suite

### DIFF
--- a/compare_tables.py
+++ b/compare_tables.py
@@ -4,6 +4,7 @@ Compare tables between two .oa files to identify changes
 """
 import sys
 import struct
+from table_a_parser import TableAParser
 
 def read_oa_file(filepath):
     """Read .oa file and return table information"""
@@ -95,7 +96,23 @@ def compare_tables(file1, file2):
             
             print(f"0x{tid:<10x} {entry['size1']:<12} {entry['size2']:<12} "
                   f"{entry['size_diff']:+12} {table_name}")
-    
+
+            # If this is the string table, show the added strings
+            if tid == 0xa:
+                parser1 = TableAParser(tables1[tid]['data'])
+                parser1.parse()
+                strings1 = {s['string'] for s in parser1.strings}
+
+                parser2 = TableAParser(tables2[tid]['data'])
+                parser2.parse()
+                strings2 = {s['string'] for s in parser2.strings}
+
+                added_strings = strings2 - strings1
+                if added_strings:
+                    print(f"    {'':<12} {'Added strings:'}")
+                    for s in sorted(list(added_strings))[:5]: # Show first 5
+                        print(f"    {'':<14} - \"{s}\"")
+
     return changed_tables, unchanged_tables
 
 def get_table_name(tid):

--- a/table_c_parser.py
+++ b/table_c_parser.py
@@ -69,59 +69,41 @@ class TableHeader:
     
     def __str__(self):
         """
-        Print ALL header data - following binary_curator principle.
-        Every claimed byte must be printed or asserted.
-        Now treats header as a struct with named and unknown fields.
+        Prints all header fields sequentially, preserving their original order.
+        Summarizes long runs of identical values to maintain readability.
         """
         lines = [
             f"Header ID: {format_int(self.header_id)}",
             f"Header Size: {self.pointer_list_end_offset} bytes",
             f"Total Fields: {len(self.raw_all_fields)}",
             "",
-            "=== KNOWN FIELDS ===",
-            f"  [Field 0] first_record_offset: 0x{self.first_record_offset:04x}",
+            "--- Header Fields (in original order) ---"
         ]
-        
-        # Boundary offsets (31-33) - known to be true offsets
-        if self.boundary_offsets_31_33:
-            lines.append("")
-            lines.append("  [Fields 31-33] boundary_offsets (verified record boundaries):")
-            for i, offset in enumerate(self.boundary_offsets_31_33, start=31):
-                lines.append(f"    [{i:03d}]: 0x{offset:04x}")
-        
-        # Unknown offset fields (1-30)
-        if self.unknown_offsets_1_30:
-            lines.append("")
-            lines.append("  [Fields 1-30] unknown_offsets (purpose unclear):")
-            for i, val in enumerate(self.unknown_offsets_1_30, start=1):
-                # Only show non-zero values to reduce clutter
-                if val != 0:
-                    lines.append(f"    [{i:03d}]: 0x{val:x}")
-        
-        # Config values (34+)
-        if self.config_values:
-            lines.append("")
-            lines.append("=== CONFIG VALUES (Fields 34+) ===")
-            i = 0
-            offset_base = 34
-            while i < len(self.config_values):
-                val = self.config_values[i]
-                # Check for repeated values
-                if val == 0 and i + 1 < len(self.config_values):
-                    # Count consecutive zeros
-                    count = 1
-                    j = i + 1
-                    while j < len(self.config_values) and self.config_values[j] == 0:
-                        count += 1
-                        j += 1
-                    if count >= 4:  # Only summarize if 4+ consecutive zeros
-                        lines.append(f"  [{offset_base+i:03d}-{offset_base+j-1:03d}]: 0x{val:016x} (repeats {count} times)")
-                        i = j
-                        continue
-                # Show non-zero values
-                if val != 0:
-                    lines.append(f"  [{offset_base+i:03d}]: 0x{val:x}")
-                i += 1
+
+        if not self.raw_all_fields:
+            lines.append("  (No fields to display)")
+            return "\n".join(lines)
+
+        i = 0
+        while i < len(self.raw_all_fields):
+            val = self.raw_all_fields[i]
+
+            # Check for repeated values
+            count = 1
+            j = i + 1
+            while j < len(self.raw_all_fields) and self.raw_all_fields[j] == val:
+                count += 1
+                j += 1
+
+            if count > 3:  # Summarize if 4 or more repeats
+                lines.append(f"  [Fields {i:03d}-{j-1:03d}]: 0x{val:x} (repeats {count} times)")
+                i = j  # Move index past the repeated block
+            else:
+                # Print individual fields if not part of a long run
+                for k in range(i, j):
+                    field_val = self.raw_all_fields[k]
+                    lines.append(f"  [Field {k:03d}]: 0x{field_val:x}")
+                i = j
         
         return "\n".join(lines)
 

--- a/test_analysis_tools.sh
+++ b/test_analysis_tools.sh
@@ -49,9 +49,9 @@ run_test "parser.py --hexdump mode" \
 run_test "compare_tables.py" \
     "python3 compare_tables.py sch_old.oa sch_new.oa"
 
-# Test 5: analyze_changes.py
-run_test "analyze_changes.py" \
-    "python3 analyze_changes.py sch_old.oa sch_new.oa"
+# Test 5: compare_tables.py (replaces analyze_changes.py)
+run_test "compare_tables.py (replaces analyze_changes.py)" \
+    "python3 compare_tables.py sch_old.oa sch_new.oa"
 
 # Test 6: String table finds "popop" in sch_old.oa
 run_test "Find 'popop' in sch_old.oa" \
@@ -65,9 +65,9 @@ run_test "Find 'THISISNOWTHERESISTOR' in sch_new.oa" \
 run_test "Detect 7 changed tables" \
     "python3 compare_tables.py sch_old.oa sch_new.oa | grep -q 'Tables that changed: 7'"
 
-# Test 9: analyze_changes detects string addition
+# Test 9: compare_tables detects string addition
 run_test "Detect string addition" \
-    "python3 analyze_changes.py sch_old.oa sch_new.oa | grep -q 'THISISNOWTHERESISTOR'"
+    "python3 compare_tables.py sch_old.oa sch_new.oa | grep -q 'THISISNOWTHERESISTOR'"
 
 # Test 10: String table size increase detected
 run_test "Detect string table size increase" \


### PR DESCRIPTION
The `TableHeader` class in `table_c_parser.py` was sorting fields into "known" and "unknown" categories, which made the output confusing and did not reflect the actual data structure. This change modifies the `__str__` method to print the fields in their original order, improving readability.

Additionally, the test suite was found to be broken, referencing a non-existent `analyze_changes.py` script. This prevented proper validation of any changes. The test suite has been repaired by updating `test_analysis_tools.sh` to call the correct script, `compare_tables.py`. The `compare_tables.py` script was also enhanced to report added strings, aligning it with the intent of the original test.